### PR TITLE
Update entWatch core, interface, and message modules

### DIFF
--- a/configs/entwatch/colors/classic.cfg
+++ b/configs/entwatch/colors/classic.cfg
@@ -1,0 +1,12 @@
+"colors"
+{
+    "color_tag"         "E01B5D"
+    "color_name"        "EDEDED"
+    "color_steamid"     "B2B2B2"
+    "color_use"         "67ADDF"
+    "color_pickup"      "C9EF66"
+    "color_drop"        "E562BA"
+    "color_disconnect"  "F1B567"
+    "color_death"       "F1B567"
+    "color_warning"     "F16767"
+}

--- a/configs/entwatch/colors/template.txt
+++ b/configs/entwatch/colors/template.txt
@@ -1,0 +1,12 @@
+"colors"
+{
+    "color_tag"         ""
+    "color_name"        ""
+    "color_steamid"     ""
+    "color_use"         ""
+    "color_pickup"      ""
+    "color_drop"        ""
+    "color_disconnect"  ""
+    "color_death"       ""
+    "color_warning"     ""
+}

--- a/scripting/entWatch-core.sp
+++ b/scripting/entWatch-core.sp
@@ -1006,7 +1006,7 @@ stock Action OnButtonOutput(const char[] sOutput, int iButton, int iClient, floa
 stock Action OnCounterOutput(const char[] sOutput, int iButton, int iClient, float flDelay)
 {
 	if (!IsValidEntity(iButton) || !g_hArray_Items.Length)
-		return Plugin_Handled;
+		return Plugin_Continue;
 
 	for (int iItemID; iItemID < g_hArray_Items.Length; iItemID++)
 	{
@@ -1024,7 +1024,7 @@ stock Action OnCounterOutput(const char[] sOutput, int iButton, int iClient, flo
 		}
 	}
 
-	return Plugin_Handled;
+	return Plugin_Continue;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -1096,7 +1096,7 @@ stock Action ProcessButtonPress(int iClient, CItem hItem, CItemButton hItemButto
 stock Action ProcessCounterValue(int iClient, CItem hItem, CItemButton hItemButton)
 {
 	if (hItem.flReadyTime > g_flGameFrameTime)
-		return Plugin_Handled;
+		return Plugin_Continue;
 
 	int iNewCurrentUses = 0;
 
@@ -1107,7 +1107,7 @@ stock Action ProcessCounterValue(int iClient, CItem hItem, CItemButton hItemButt
 			if (hItemButton.flReadyTime < g_flGameFrameTime)
 				hItemButton.flReadyTime = g_flGameFrameTime + hItemButton.hConfigButton.flButtonCooldown;
 			else
-				return Plugin_Handled;
+				return Plugin_Continue;
 		}
 		case EW_BUTTON_MODE_MAXUSES:
 		{
@@ -1123,7 +1123,7 @@ stock Action ProcessCounterValue(int iClient, CItem hItem, CItemButton hItemButt
 			if (iNewCurrentUses <= hItemButton.iCurrentUses)
 			{
 				hItemButton.iCurrentUses = iNewCurrentUses;
-				return Plugin_Handled;
+				return Plugin_Continue;
 			}
 
 			hItemButton.iCurrentUses = iNewCurrentUses;
@@ -1143,7 +1143,7 @@ stock Action ProcessCounterValue(int iClient, CItem hItem, CItemButton hItemButt
 			if (iNewCurrentUses <= hItemButton.iCurrentUses)
 			{
 				hItemButton.iCurrentUses = iNewCurrentUses;
-				return Plugin_Handled;
+				return Plugin_Continue;
 			}
 
 			hItemButton.iCurrentUses = iNewCurrentUses;

--- a/scripting/entWatch-core.sp
+++ b/scripting/entWatch-core.sp
@@ -236,8 +236,8 @@ stock bool LoadConfig(bool bLoopEntities = false)
 						hConfigButton.flButtonCooldown = hConfigFile.GetFloat("cooldown");
 						hConfigButton.flItemCooldown   = hConfigFile.GetFloat("itemcooldown");
 
-						hConfigButton.bShowActivate = view_as<bool>(hConfigFile.GetNum("showactivate", 1));
-						hConfigButton.bShowCooldown = view_as<bool>(hConfigFile.GetNum("showcooldown", 1));
+						hConfigButton.bShowActivate = view_as<bool>(hConfigFile.GetNum("showactivate", 0));
+						hConfigButton.bShowCooldown = view_as<bool>(hConfigFile.GetNum("showcooldown", 0));
 
 						hConfig.hButtons.Push(hConfigButton);
 					}
@@ -1133,7 +1133,7 @@ stock Action ProcessCounterValue(int iClient, CItem hItem, CItemButton hItemButt
 		{
 			int iCounterMax = RoundFloat(GetEntPropFloat(hItemButton.iButton, Prop_Data, "m_flMax"));
 			int iCounterMin = RoundFloat(GetEntPropFloat(hItemButton.iButton, Prop_Data, "m_flMin"));
-			int iMaxUses = iCounterMax - iCounterMin;
+			hItemButton.hConfigButton.iMaxUses = iCounterMax - iCounterMin;
 
 			if (hItemButton.hConfigButton.iType == EW_BUTTON_TYPE_COUNTERUP)
 				iNewCurrentUses = RoundFloat(GetEntPropFloat(hItemButton.iButton, Prop_Data, "m_OutValue")) - iCounterMin;
@@ -1148,7 +1148,7 @@ stock Action ProcessCounterValue(int iClient, CItem hItem, CItemButton hItemButt
 
 			hItemButton.iCurrentUses = iNewCurrentUses;
 
-			if (hItemButton.iCurrentUses >= iMaxUses)
+			if (hItemButton.iCurrentUses >= hItemButton.hConfigButton.iMaxUses)
 				hItemButton.flReadyTime = g_flGameFrameTime + hItemButton.hConfigButton.flButtonCooldown;
 		}
 		case EW_BUTTON_MODE_COUNTERVALUE:

--- a/scripting/entWatch-messages.sp
+++ b/scripting/entWatch-messages.sp
@@ -21,27 +21,27 @@ ConVar g_hCVar_MessageMode;
 /* STRUCTS */
 enum struct ColorStruct
 {
-	char sTag[8];           // String: Hex color of entwatch tag
-	char sName[8];          // String: Hex color of player name
-	char sAuthID[8];        // String: Hex color of player steam ID
-	char sActivate[8];      // String: Hex color of item use message
-	char sPickup[8];        // String: Hex color of item pickup message
-	char sDrop[8];          // String: Hex color of item drop message
-	char sDeath[8];         // String: Hex color of player death message
-	char sDisconnect[8];    // String: Hex color of player disconnect message
-	char sWarning[8];       // String: Hex color of warning message
+	char sTag[8];        // String: Hex color of entwatch tag
+	char sName[8];       // String: Hex color of player name
+	char sAuthID[8];     // String: Hex color of player steam ID
+	char sActivate[8];   // String: Hex color of item use message
+	char sPickup[8];     // String: Hex color of item pickup message
+	char sDrop[8];       // String: Hex color of item drop message
+	char sDeath[8];      // String: Hex color of player death message
+	char sDisconnect[8]; // String: Hex color of player disconnect message
+	char sWarning[8];    // String: Hex color of warning message
 
 	void Reset()
 	{
-		this.sTag           = "E11E64";
-		this.sName          = "F0F0F0";
-		this.sAuthID        = "B4B4B4";
-		this.sActivate      = "64AFE1";
-		this.sPickup        = "AFE164";
-		this.sDrop          = "E164AF";
-		this.sDeath         = "E1AF64";
-		this.sDisconnect    = "E1AF64";
-		this.sWarning       = "E1AF64";
+		this.sTag        = "E11E64";
+		this.sName       = "F0F0F0";
+		this.sAuthID     = "B4B4B4";
+		this.sActivate   = "64AFE1";
+		this.sPickup     = "AFE164";
+		this.sDrop       = "E164AF";
+		this.sDeath      = "E1AF64";
+		this.sDisconnect = "E1AF64";
+		this.sWarning    = "E1AF64";
 	}
 }
 
@@ -65,9 +65,9 @@ public void OnPluginStart()
 {
 	LoadTranslations("entWatch.phrases");
 
-	g_hCVar_MessageMode = CreateConVar("sm_emessages_mode", "1", "Entwatch message recipient mode (1 = All, 2 = Team Only + Admin, 3 = Team Only)", FCVAR_NONE, true, 1.0, true, 3.0);
-	g_hCVar_UseHEXColors = CreateConVar("sm_emessages_usehex", "1", "Allow HEX color codes to be used.", FCVAR_NONE, true, 0.0, true, 1.0);
-	g_hCVar_ColorConfig = CreateConVar("sm_emessages_config", "classic", "Name of entWatch-message color config file");
+	g_hCVar_MessageMode  = CreateConVar("sm_emessages_mode",   "1",       "Entwatch message recipient mode (1 = All, 2 = Team Only + Admin, 3 = Team Only)", FCVAR_NONE, true, 1.0, true, 3.0);
+	g_hCVar_UseHEXColors = CreateConVar("sm_emessages_usehex", "1",       "Allow HEX color codes to be used.", FCVAR_NONE, true, 0.0, true, 1.0);
+	g_hCVar_ColorConfig  = CreateConVar("sm_emessages_config", "classic", "Name of entWatch-message color config file");
 	g_hCVar_ColorConfig.AddChangeHook(OnConVarChange);
 
 	LoadColors();
@@ -102,15 +102,15 @@ stock void LoadColors()
 		return;
 	}
 
-	kv.GetString("color_tag",           g_colorStruct.sTag,         sizeof(g_colorStruct.sTag),         g_colorStruct.sTag);
-	kv.GetString("color_name",          g_colorStruct.sName,        sizeof(g_colorStruct.sName),        g_colorStruct.sName);
-	kv.GetString("color_steamid",       g_colorStruct.sAuthID,      sizeof(g_colorStruct.sAuthID),      g_colorStruct.sAuthID);
-	kv.GetString("color_use",           g_colorStruct.sActivate,    sizeof(g_colorStruct.sActivate),    g_colorStruct.sActivate);
-	kv.GetString("color_pickup",        g_colorStruct.sPickup,      sizeof(g_colorStruct.sPickup),      g_colorStruct.sPickup);
-	kv.GetString("color_drop",          g_colorStruct.sDrop,        sizeof(g_colorStruct.sDrop),        g_colorStruct.sDrop);
-	kv.GetString("color_death",         g_colorStruct.sDeath,       sizeof(g_colorStruct.sDeath),       g_colorStruct.sDeath);
-	kv.GetString("color_disconnect",    g_colorStruct.sDisconnect,  sizeof(g_colorStruct.sDisconnect),  g_colorStruct.sDisconnect);
-	kv.GetString("color_warning",       g_colorStruct.sWarning,     sizeof(g_colorStruct.sWarning),     g_colorStruct.sWarning);
+	kv.GetString("color_tag",        g_colorStruct.sTag,        sizeof(g_colorStruct.sTag),        g_colorStruct.sTag);
+	kv.GetString("color_name",       g_colorStruct.sName,       sizeof(g_colorStruct.sName),       g_colorStruct.sName);
+	kv.GetString("color_steamid",    g_colorStruct.sAuthID,     sizeof(g_colorStruct.sAuthID),     g_colorStruct.sAuthID);
+	kv.GetString("color_use",        g_colorStruct.sActivate,   sizeof(g_colorStruct.sActivate),   g_colorStruct.sActivate);
+	kv.GetString("color_pickup",     g_colorStruct.sPickup,     sizeof(g_colorStruct.sPickup),     g_colorStruct.sPickup);
+	kv.GetString("color_drop",       g_colorStruct.sDrop,       sizeof(g_colorStruct.sDrop),       g_colorStruct.sDrop);
+	kv.GetString("color_death",      g_colorStruct.sDeath,      sizeof(g_colorStruct.sDeath),      g_colorStruct.sDeath);
+	kv.GetString("color_disconnect", g_colorStruct.sDisconnect, sizeof(g_colorStruct.sDisconnect), g_colorStruct.sDisconnect);
+	kv.GetString("color_warning",    g_colorStruct.sWarning,    sizeof(g_colorStruct.sWarning),    g_colorStruct.sWarning);
 
 	delete kv;
 }
@@ -164,7 +164,7 @@ public void EW_OnClientItemWeaponInteract(int iClient, CItem hItem, int iInterac
 		char sItemColor[8];
 		hItem.hConfig.GetColor(sItemColor, sizeof(sItemColor));
 
-		EW_PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, sColor, sTranslation, sItemColor, sItemName);
+		PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, sColor, sTranslation, sItemColor, sItemName);
 	}
 	else
 	{
@@ -187,7 +187,7 @@ public void EW_OnClientItemWeaponInteract(int iClient, CItem hItem, int iInterac
 				strcopy(sTeamColor, sizeof(sTeamColor), "\x08");
 		}
 
-		EW_PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, sTranslation, sTeamColor, sItemName);
+		PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, sTranslation, sTeamColor, sItemName);
 	}
 }
 
@@ -217,9 +217,9 @@ public void EW_OnClientItemButtonInteract(int iClient, CItemButton hItemButton)
 		hItemButton.hItem.hConfig.GetColor(sItemColor, sizeof(sItemColor));
 
 		if (strlen(sButtonName) != 0)
-			EW_PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s \x01(\x07%6s%s\x01)", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName, sItemColor, sButtonName);
+			PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s \x01(\x07%6s%s\x01)", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName, sItemColor, sButtonName);
 		else
-			EW_PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName);
+			PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName);
 	}
 	else
 	{
@@ -237,16 +237,16 @@ public void EW_OnClientItemButtonInteract(int iClient, CItemButton hItemButton)
 		}
 
 		if (strlen(sButtonName) != 0)
-			EW_PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s (%s)", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName, sButtonName);
+			PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s (%s)", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName, sButtonName);
 		else
-			EW_PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName);
+			PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName);
 	}
 }
 
 //----------------------------------------------------------------------------------------------------
 // Purpose:
 //----------------------------------------------------------------------------------------------------
-stock void EW_PrintChatMessage(int iClient, const char[] sMessage, any ...)
+stock void PrintChatMessage(int iClient, const char[] sMessage, any ...)
 {
 	char sBuffer[255];
 	VFormat(sBuffer, sizeof(sBuffer), sMessage, 3);
@@ -263,7 +263,7 @@ stock void EW_PrintChatMessage(int iClient, const char[] sMessage, any ...)
 					continue;
 
 				if (GetClientTeam(i) == iTeam || CheckCommandAccess(i, "", ADMFLAG_GENERIC))
-					PrintToChat(i, "%s", sBuffer);
+					PrintToChat(i, sBuffer);
 			}
 		}
 		case 3:
@@ -274,9 +274,9 @@ stock void EW_PrintChatMessage(int iClient, const char[] sMessage, any ...)
 					continue;
 
 				if (GetClientTeam(i) == iTeam)
-					PrintToChat(i, "%s", sBuffer);
+					PrintToChat(i, sBuffer);
 			}
 		}
-		default: PrintToChatAll("%s", sBuffer);
+		default: PrintToChatAll(sBuffer);
 	}
 }

--- a/scripting/entWatch-messages.sp
+++ b/scripting/entWatch-messages.sp
@@ -13,18 +13,37 @@
 #include <sourcemod>
 #include <entWatch_core>
 
-/* CONVARS *//*
-ConVar g_hCVar_UseHEXColors = null;
+/* CONVARS */
+ConVar g_hCVar_UseHEXColors;
+ConVar g_hCVar_ColorConfig;
 
-ConVar g_hCVar_Color_Tag = null;
-ConVar g_hCVar_Color_Names = null;
-ConVar g_hCVar_Color_AuthID = null;
-ConVar g_hCVar_Color_Activate = null;
-ConVar g_hCVar_Color_Pickup = null;
-ConVar g_hCVar_Color_Drop = null;
-ConVar g_hCVar_Color_Death = null;
-ConVar g_hCVar_Color_Disconnect = null;
-ConVar g_hCVar_Color_Warning = null;*/
+enum struct ColorStruct
+{
+	char sTag[8];           // String: Hex color of entwatch tag
+	char sName[8];          // String: Hex color of player name
+	char sAuthID[8];        // String: Hex color of player steam ID
+	char sActivate[8];      // String: Hex color of item use message
+	char sPickup[8];        // String: Hex color of item pickup message
+	char sDrop[8];          // String: Hex color of item drop message
+	char sDeath[8];         // String: Hex color of player death message
+	char sDisconnect[8];    // String: Hex color of player disconnect message
+	char sWarning[8];       // String: Hex color of warning message
+
+	void Reset()
+	{
+		this.sTag           = "E11E64";
+		this.sName          = "F0F0F0";
+		this.sAuthID        = "B4B4B4";
+		this.sActivate      = "64AFE1";
+		this.sPickup        = "AFE164";
+		this.sDrop          = "E164AF";
+		this.sDeath         = "E1AF64";
+		this.sDisconnect    = "E1AF64";
+		this.sWarning       = "E1AF64";
+	}
+}
+
+ColorStruct g_colorStruct;
 
 //----------------------------------------------------------------------------------------------------
 // Purpose:
@@ -43,20 +62,54 @@ public Plugin myinfo =
 public void OnPluginStart()
 {
 	LoadTranslations("entWatch.phrases");
-/*
+
 	g_hCVar_UseHEXColors = CreateConVar("sm_emessages_usehex", "1", "Allow HEX color codes to be used.", FCVAR_NONE, true, 0.0, true, 1.0);
+	g_hCVar_ColorConfig = CreateConVar("sm_emessages_config", "classic", "Name of entWatch-message color config file");
+	g_hCVar_ColorConfig.AddChangeHook(OnConVarChange);
 
-	g_hCVar_Color_Tag        = CreateConVar("sm_emessage_color_tag",        "E11E64", "The HEX color code for the tags.",                FCVAR_NONE);
-	g_hCVar_Color_Names      = CreateConVar("sm_emessage_color_names",      "F0F0F0", "The HEX color code for names.",                   FCVAR_NONE);
-	g_hCVar_Color_AuthID     = CreateConVar("sm_emessage_color_authid",     "B4B4B4", "The HEX color code for the authids.",             FCVAR_NONE);
-	g_hCVar_Color_Activate   = CreateConVar("sm_emessage_color_activate",   "64AFE1", "The HEX color code for the activation messages.", FCVAR_NONE);
-	g_hCVar_Color_Pickup     = CreateConVar("sm_emessage_color_pickup",     "AFE164", "The HEX color code for the pickup messages.",     FCVAR_NONE);
-	g_hCVar_Color_Drop       = CreateConVar("sm_emessage_color_drop",       "E164AF", "The HEX color code for the drop messages.",       FCVAR_NONE);
-	g_hCVar_Color_Death      = CreateConVar("sm_emessage_color_death",      "E1AF64", "The HEX color code for the death messages.",      FCVAR_NONE);
-	g_hCVar_Color_Disconnect = CreateConVar("sm_emessage_color_disconnect", "E1AF64", "The HEX color code for the disconnect messages.", FCVAR_NONE);
-	g_hCVar_Color_Warning    = CreateConVar("sm_emessage_color_warning",    "E16464", "The HEX color code for the warning messages.",    FCVAR_NONE);
+	LoadColors();
+	AutoExecConfig();
+}
 
-	AutoExecConfig();*/
+//----------------------------------------------------------------------------------------------------
+// Purpose:
+//----------------------------------------------------------------------------------------------------
+public void OnConVarChange(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	if (convar == g_hCVar_ColorConfig)
+		LoadColors();
+}
+
+//----------------------------------------------------------------------------------------------------
+// Purpose:
+//----------------------------------------------------------------------------------------------------
+stock void LoadColors()
+{
+	g_colorStruct.Reset();
+
+	char sConfig[32], sFilePath[PLATFORM_MAX_PATH];
+	g_hCVar_ColorConfig.GetString(sConfig, sizeof(sConfig));
+	BuildPath(Path_SM, sFilePath, sizeof(sFilePath), "configs/entwatch/colors/%s.cfg", sConfig);
+
+	KeyValues kv = new KeyValues("colors");
+	if (!kv.ImportFromFile(sFilePath))
+	{
+		delete kv;
+		LogError("[entWatch-messages] Failed to load color config. Falling back on default colors.");
+		return;
+	}
+
+	kv.GetString("color_tag",           g_colorStruct.sTag,         sizeof(g_colorStruct.sTag),         g_colorStruct.sTag);
+	kv.GetString("color_name",          g_colorStruct.sName,        sizeof(g_colorStruct.sName),        g_colorStruct.sName);
+	kv.GetString("color_steamid",       g_colorStruct.sAuthID,      sizeof(g_colorStruct.sAuthID),      g_colorStruct.sAuthID);
+	kv.GetString("color_use",           g_colorStruct.sActivate,    sizeof(g_colorStruct.sActivate),    g_colorStruct.sActivate);
+	kv.GetString("color_pickup",        g_colorStruct.sPickup,      sizeof(g_colorStruct.sPickup),      g_colorStruct.sPickup);
+	kv.GetString("color_drop",          g_colorStruct.sDrop,        sizeof(g_colorStruct.sDrop),        g_colorStruct.sDrop);
+	kv.GetString("color_death",         g_colorStruct.sDeath,       sizeof(g_colorStruct.sDeath),       g_colorStruct.sDeath);
+	kv.GetString("color_disconnect",    g_colorStruct.sDisconnect,  sizeof(g_colorStruct.sDisconnect),  g_colorStruct.sDisconnect);
+	kv.GetString("color_warning",       g_colorStruct.sWarning,     sizeof(g_colorStruct.sWarning),     g_colorStruct.sWarning);
+
+	delete kv;
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -75,38 +128,47 @@ public void EW_OnClientItemWeaponInteract(int iClient, CItem hItem, int iInterac
 	char sClientAuth[32];
 	GetClientAuthId(iClient, AuthId_Steam2, sClientAuth, sizeof(sClientAuth));
 
-	char sTranslation[32];
+	char sTranslation[32], sColor[8];
 	switch (iInteractionType)
 	{
 		case EW_WEAPON_INTERACTION_DROP:
+		{
 			Format(sTranslation, sizeof(sTranslation), "Item Drop");
-
+			Format(sColor, sizeof(sColor), g_colorStruct.sDrop);
+		}
 		case EW_WEAPON_INTERACTION_DEATH:
+		{
 			Format(sTranslation, sizeof(sTranslation), "Item Death");
-
+			Format(sColor, sizeof(sColor), g_colorStruct.sDeath);
+		}
 		case EW_WEAPON_INTERACTION_PICKUP:
+		{
 			Format(sTranslation, sizeof(sTranslation), "Item Pickup");
-
+			Format(sColor, sizeof(sColor), g_colorStruct.sPickup);
+		}
 		case EW_WEAPON_INTERACTION_DISCONNECT:
+		{
 			Format(sTranslation, sizeof(sTranslation), "Item Disconnect");
+			Format(sColor, sizeof(sColor), g_colorStruct.sDisconnect);
+		}
 	}
 
 	char sItemName[32];
 	hItem.hConfig.GetName(sItemName, sizeof(sItemName));
 
-	if (IsSource2009())
+	if (g_hCVar_UseHEXColors.BoolValue)
 	{
 		char sItemColor[8];
 		hItem.hConfig.GetColor(sItemColor, sizeof(sItemColor));
 
-		PrintToChatAll("\x04[entWatch] \x01%s (\x05%s\x01) %t \x07%6s%s", sClientName, sClientAuth, sTranslation, sItemColor, sItemName);
+		PrintToChatAll("\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, sColor, sTranslation, sItemColor, sItemName);
 	}
 	else
 	{
-		//CSGO Colors.
-		//x02 = Zombies
-		//x08 = Neutral
-		//x0C = Humans
+		// CSGO Colors.
+		// x02 = Zombies
+		// x08 = Neutral
+		// x0C = Humans
 
 		char sTeamColor[8];
 		switch (GetClientTeam(iClient))
@@ -144,15 +206,15 @@ public void EW_OnClientItemButtonInteract(int iClient, CItemButton hItemButton)
 	hItemButton.hItem.hConfig.GetName(sItemName, sizeof(sItemName));
 	hItemButton.hConfigButton.GetName(sButtonName, sizeof(sButtonName));
 
-	if (IsSource2009())
+	if (g_hCVar_UseHEXColors.BoolValue)
 	{
 		char sItemColor[8];
 		hItemButton.hItem.hConfig.GetColor(sItemColor, sizeof(sItemColor));
 
 		if (strlen(sButtonName) != 0)
-			PrintToChatAll("\x04[entWatch] \x01%s (\x05%s\x01) %t \x07%6s%s (%s)", sClientName, sClientAuth, "Item Activate", sItemColor, sItemName, sButtonName);
+			PrintToChatAll("\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s \x01(\x07%6s%s\x01)", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName, sItemColor, sButtonName);
 		else
-			PrintToChatAll("\x04[entWatch] \x01%s (\x05%s\x01) %t \x07%6s%s", sClientName, sClientAuth, "Item Activate", sItemColor, sItemName);
+			PrintToChatAll("\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName);
 	}
 	else
 	{
@@ -173,21 +235,4 @@ public void EW_OnClientItemButtonInteract(int iClient, CItemButton hItemButton)
 		else
 			PrintToChatAll(" \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName);
 	}
-}
-
-//----------------------------------------------------------------------------------------------------
-// Purpose:
-//----------------------------------------------------------------------------------------------------
-stock bool IsSource2009()
-{
-	static bool bHasChecked = false;
-	static bool bIsSource2009 = false;
-
-	if (!bHasChecked)
-	{
-		bHasChecked = true;
-		bIsSource2009 = (GetEngineVersion() == Engine_CSS || GetEngineVersion() == Engine_HL2DM || GetEngineVersion() == Engine_DODS || GetEngineVersion() == Engine_TF2);
-	}
-
-	return bIsSource2009;
 }

--- a/scripting/entWatch-messages.sp
+++ b/scripting/entWatch-messages.sp
@@ -164,35 +164,7 @@ public void EW_OnClientItemWeaponInteract(int iClient, CItem hItem, int iInterac
 		char sItemColor[8];
 		hItem.hConfig.GetColor(sItemColor, sizeof(sItemColor));
 
-		switch (g_hCVar_MessageMode.IntValue)
-		{
-			case 2:
-			{
-				int iTeam = GetClientTeam(iClient);
-				for (int i; i <= MaxClients; i++)
-				{
-					if (!IsClientInGame(i) || GetClientTeam(i) != iTeam || !CheckCommandAccess(i, "", ADMFLAG_BAN))
-						continue;
-
-					PrintToChat(i, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, sColor, sTranslation, sItemColor, sItemName);
-				}
-			}
-			case 3:
-			{
-				int iTeam = GetClientTeam(iClient);
-				for (int i; i <= MaxClients; i++)
-				{
-					if (!IsClientInGame(i) || GetClientTeam(i) != iTeam)
-						continue;
-
-					PrintToChat(i, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, sColor, sTranslation, sItemColor, sItemName);
-				}
-			}
-			default:
-			{
-				PrintToChatAll("\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, sColor, sTranslation, sItemColor, sItemName);
-			}
-		}
+		EW_PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, sColor, sTranslation, sItemColor, sItemName);
 	}
 	else
 	{
@@ -200,6 +172,7 @@ public void EW_OnClientItemWeaponInteract(int iClient, CItem hItem, int iInterac
 		// x02 = Zombies
 		// x08 = Neutral
 		// x0C = Humans
+		// CSGO: Requires a character before colors will work, so add a space.
 
 		char sTeamColor[8];
 		int iTeam = GetClientTeam(iClient);
@@ -214,34 +187,7 @@ public void EW_OnClientItemWeaponInteract(int iClient, CItem hItem, int iInterac
 				strcopy(sTeamColor, sizeof(sTeamColor), "\x08");
 		}
 
-		switch (g_hCVar_MessageMode.IntValue)
-		{
-			case 2:
-			{
-				for (int i; i <= MaxClients; i++)
-				{
-					if (!IsClientInGame(i) || GetClientTeam(i) != iTeam || !CheckCommandAccess(i, "", ADMFLAG_BAN))
-						continue;
-
-					PrintToChat(i, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, sTranslation, sTeamColor, sItemName);
-				}
-			}
-			case 3:
-			{
-				for (int i; i <= MaxClients; i++)
-				{
-					if (!IsClientInGame(i) || GetClientTeam(i) != iTeam)
-						continue;
-
-					PrintToChat(i, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, sTranslation, sTeamColor, sItemName);
-				}
-			}
-			default:
-			{
-				// CSGO: Requires a character before colors will work, so add a space.
-				PrintToChatAll(" \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, sTranslation, sTeamColor, sItemName);
-			}
-		}
+		EW_PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, sTranslation, sTeamColor, sItemName);
 	}
 }
 
@@ -270,44 +216,10 @@ public void EW_OnClientItemButtonInteract(int iClient, CItemButton hItemButton)
 		char sItemColor[8];
 		hItemButton.hItem.hConfig.GetColor(sItemColor, sizeof(sItemColor));
 
-		switch (g_hCVar_MessageMode.IntValue)
-		{
-			case 2:
-			{
-				int iTeam = GetClientTeam(iClient);
-				for (int i; i <= MaxClients; i++)
-				{
-					if (!IsClientInGame(i) || GetClientTeam(i) != iTeam || !CheckCommandAccess(i, "", ADMFLAG_BAN))
-						continue;
-
-					if (strlen(sButtonName) != 0)
-						PrintToChat(i, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s \x01(\x07%6s%s\x01)", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName, sItemColor, sButtonName);
-					else
-						PrintToChat(i, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName);
-				}
-			}
-			case 3:
-			{
-				int iTeam = GetClientTeam(iClient);
-				for (int i; i <= MaxClients; i++)
-				{
-					if (!IsClientInGame(i) || GetClientTeam(i) != iTeam)
-						continue;
-
-					if (strlen(sButtonName) != 0)
-						PrintToChat(i, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s \x01(\x07%6s%s\x01)", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName, sItemColor, sButtonName);
-					else
-						PrintToChat(i, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName);
-				}
-			}
-			default:
-			{
-				if (strlen(sButtonName) != 0)
-					PrintToChatAll("\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s \x01(\x07%6s%s\x01)", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName, sItemColor, sButtonName);
-				else
-					PrintToChatAll("\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName);
-			}
-		}
+		if (strlen(sButtonName) != 0)
+			EW_PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s \x01(\x07%6s%s\x01)", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName, sItemColor, sButtonName);
+		else
+			EW_PrintChatMessage(iClient, "\x07%6s[entWatch] \x07%6s%s \x01(\x07%6s%s\x01) \x07%6s%t \x07%6s%s", g_colorStruct.sTag, g_colorStruct.sName, sClientName, g_colorStruct.sAuthID, sClientAuth, g_colorStruct.sActivate, "Item Activate", sItemColor, sItemName);
 	}
 	else
 	{
@@ -324,42 +236,47 @@ public void EW_OnClientItemButtonInteract(int iClient, CItemButton hItemButton)
 				strcopy(sTeamColor, sizeof(sTeamColor), "\x08");
 		}
 
-		switch (g_hCVar_MessageMode.IntValue)
+		if (strlen(sButtonName) != 0)
+			EW_PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s (%s)", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName, sButtonName);
+		else
+			EW_PrintChatMessage(iClient, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName);
+	}
+}
+
+//----------------------------------------------------------------------------------------------------
+// Purpose:
+//----------------------------------------------------------------------------------------------------
+stock void EW_PrintChatMessage(int iClient, const char[] sMessage, any ...)
+{
+	char sBuffer[255];
+	VFormat(sBuffer, sizeof(sBuffer), sMessage, 3);
+
+	int iTeam = GetClientTeam(iClient);
+
+	switch (g_hCVar_MessageMode.IntValue)
+	{
+		case 2:
 		{
-			case 2:
+			for (int i; i <= MaxClients; i++)
 			{
-				for (int i; i <= MaxClients; i++)
-				{
-					if (!IsClientInGame(i) || GetClientTeam(i) != iTeam || !CheckCommandAccess(i, "", ADMFLAG_BAN))
-						continue;
+				if (!IsClientInGame(i))
+					continue;
 
-					if (strlen(sButtonName) != 0)
-						PrintToChat(i, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s (%s)", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName, sButtonName);
-					else
-						PrintToChat(i, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName);
-				}
-			}
-			case 3:
-			{
-				for (int i; i <= MaxClients; i++)
-				{
-					if (!IsClientInGame(i) || GetClientTeam(i) != iTeam)
-						continue;
-
-					if (strlen(sButtonName) != 0)
-						PrintToChat(i, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s (%s)", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName, sButtonName);
-					else
-						PrintToChat(i, " \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName);
-				}
-			}
-			default:
-			{
-				// CSGO: Requires a character before colors will work, so add a space.
-				if (strlen(sButtonName) != 0)
-					PrintToChatAll(" \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s (%s)", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName, sButtonName);
-				else
-					PrintToChatAll(" \x04[entWatch] \x01%s (\x05%s\x01) %t %s%s", sClientName, sClientAuth, "Item Activate", sTeamColor, sItemName);
+				if (GetClientTeam(i) == iTeam || CheckCommandAccess(i, "", ADMFLAG_GENERIC))
+					PrintToChat(i, "%s", sBuffer);
 			}
 		}
+		case 3:
+		{
+			for (int i; i <= MaxClients; i++)
+			{
+				if (!IsClientInGame(i))
+					continue;
+
+				if (GetClientTeam(i) == iTeam)
+					PrintToChat(i, "%s", sBuffer);
+			}
+		}
+		default: PrintToChatAll("%s", sBuffer);
 	}
 }


### PR DESCRIPTION
This PR adds more customization to how entWatch information is displayed to clients and reworks some internal logic within the core module.

\- All counter hooks actions have been changed to `Plugin_Continue` to ensure no interference with map functionality. *(There isn't a need for entWatch to filter counter outputs. If filter is needed, define the button separately in config instead.)*
\- Fixed `showactivate` and `showcooldown` defaulting to `True` when parsing configs since `CConfigButton.inc` defaults to `False`
\- Reworked counter maxuse logic to directly set maxuses for `EW_BUTTON_MODE_COOLDOWN_CHARGES` mode
\- Added convars for both interface and message modules on how information should be displayed (1 = Displayed to all, 2 = Team display except for admins, 3 = Team display only)
\- Added color scheme support for message module
\- Added convar to set if messages should use HEX or team colors (backwards compat with CS:GO)
\- Cleanup commented out debug code and fix formatting